### PR TITLE
Fix #5

### DIFF
--- a/pyiface/iface.py
+++ b/pyiface/iface.py
@@ -178,7 +178,7 @@ class Interface(object):
 
     def __newIfreqWithName(self):
         ifr = ifreq()
-        ifr.ifr_name = self._name
+        ifr.ifr_name = (c_ubyte*IFNAMSIZ) (*bytearray(self._name))
         return ifr
 
     def __doIoctl(self, ifr, SIOC, mutate = True):


### PR DESCRIPTION
ifr.ifr_name is not a regular string but a ctypes byte array, so name has to be turned into such array