### PR TITLE
Fix imports for Python2 and Python3

### DIFF
--- a/pyiface/__init__.py
+++ b/pyiface/__init__.py
@@ -1,5 +1,4 @@
-from ifreqioctls import *
-from iface import Interface, getIfaces
+from .iface import Interface, getIfaces
 
 __all__=['Interface', 'getIfaces']
 

--- a/pyiface/iface.py
+++ b/pyiface/iface.py
@@ -5,7 +5,7 @@ import struct
 import socket
 
 from ctypes import *
-from ifreqioctls import *
+from .ifreqioctls import *
 from binascii import hexlify
 
 flags2str = {


### PR DESCRIPTION
I found a unique way that imports will work on Python2 and also on Python3.
Signed-off-by: Alexandru Vasiu <alexandru.vasiu@ni.com>