### PR TITLE
Fix PyIface usage with unittest framework

### DIFF
--- a/pyiface/iface.py
+++ b/pyiface/iface.py
@@ -175,11 +175,6 @@ class Interface(object):
     """
 
     def __init__(self, idx=1, name=None):
-        self.skt = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)
-        fcntl.fcntl(self.skt,
-                    fcntl.F_SETFD,
-                    fcntl.fcntl(self.skt, fcntl.F_GETFD) | fcntl.FD_CLOEXEC)
-
         self._index = idx
         self._name = name
 
@@ -197,7 +192,11 @@ class Interface(object):
 
     def __doIoctl(self, ifr, SIOC, mutate=True):
         try:
-            fcntl.ioctl(self.skt, SIOC, ifr, mutate)
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0) as skt:
+                fcntl.fcntl(skt,
+                            fcntl.F_SETFD,
+                            fcntl.fcntl(skt, fcntl.F_GETFD) | fcntl.FD_CLOEXEC)
+                fcntl.ioctl(skt, SIOC, ifr, mutate)
         except IOError as ioException:
             if ioException.errno == 99:
                 pass


### PR DESCRIPTION
Due to the fact, that the socket won't be closed explicitly, when
using unittest following warnings occur:

ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamiy.AF_INET,
type=SocketKind.SOCK_DGRAM, proto=0, laddr=('0.0.0.0', 0)>

Use with statement to create and close the socket.

Signed-off-by: user <user@ubuntuat.visionsystems.de>